### PR TITLE
Add endpoint to get transmission details

### DIFF
--- a/lib/hello_fax.rb
+++ b/lib/hello_fax.rb
@@ -32,6 +32,10 @@ module HelloFax
       self.class.get("/Accounts/#{@guid}/Transmissions")
     end
 
+    def transmission_details(transmission_guid)
+      self.class.get("/Accounts/#{@guid}/Transmissions/#{transmission_guid}")
+    end
+    
     def fax_lines
       self.class.get("/Accounts/#{@guid}/FaxLines")
     end

--- a/spec/hello_fax_spec.rb
+++ b/spec/hello_fax_spec.rb
@@ -3,6 +3,7 @@ describe HelloFax do
   it "should get account details"
   it "should put account details"
   it "should get current transmissions"
+  it "should get transmission details"
   it "should get fax lines in use"
   it "should get fax numbers available by state"
 end


### PR DESCRIPTION
There is currently no way to get transmission details for a fax.  Adding the following will get the status.  Then you can poll the transmission status if you want to send a fax synchronously.

As a quick example:

```
transmission_guid = hello_fax.send_fax(number, pdf)['Tramisssion']['Guid']
while true
  transmission_status = hello_fax.transmission_details(transmission_guid)
  return transmission_status['Transmission']['StatusCode'] unless ['T','P'].include?(transmission_status['Transmission']['StatusCode'])
end
```
